### PR TITLE
Changed the behavior for undefined variables

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -4,6 +4,8 @@ pipeline:
     - name: release
       enabled: true
       steps:
+        - name: check for release property
+          run: if [ -z "${{ release }}" ]; then echo "release property is required, exiting" && exit 1; fi
         - name: change version
           run: |
             ./mvnw versions:set -DnewVersion="${{ release }}" -DprocessAllModules >> /dev/null

--- a/src/main/java/org/verifyica/pipeliner/execution/support/Resolver.java
+++ b/src/main/java/org/verifyica/pipeliner/execution/support/Resolver.java
@@ -30,6 +30,10 @@ import org.verifyica.pipeliner.tokenizer.TokenizerException;
 /** Class to implement Resolver */
 public class Resolver {
 
+    private static final String UNRESOLVED_PROPERTY_REGEX = "(?<!\\\\)\\$\\{\\{\\s*.*\\s*}}";
+
+    private static final Pattern UNRESOLVED_PROPERTY_PATTERN = Pattern.compile(UNRESOLVED_PROPERTY_REGEX);
+
     /** Constructor */
     private Resolver() {
         // INTENTIONALLY BLANK
@@ -138,6 +142,7 @@ public class Resolver {
     public static String replaceProperties(Map<String, String> properties, String string) {
         String workingString = string;
 
+        // Replace all defined properties in the string
         for (Map.Entry<String, String> entry : properties.entrySet()) {
             String key = entry.getKey();
             String value = entry.getValue();
@@ -146,6 +151,10 @@ public class Resolver {
             String regex = "(?<!\\\\)\\$\\{\\{\\s*" + Pattern.quote(key) + "\\s*}}";
             workingString = workingString.replaceAll(regex, Matcher.quoteReplacement(value));
         }
+
+        // Remove all unresolved properties from the string
+        Matcher matcher = UNRESOLVED_PROPERTY_PATTERN.matcher(workingString);
+        workingString = matcher.replaceAll("");
 
         return workingString;
     }
@@ -189,10 +198,13 @@ public class Resolver {
         for (Token token : tokens) {
             switch (token.getType()) {
                 case PROPERTY: {
-                    String value = properties.get(token.getValue());
+                    String value = properties.getOrDefault(token.getValue(), "");
+                    // Code left in the event that we want to throw an exception if a property is unresolved
+                    /*
                     if (value == null) {
                         throw new ResolverException(format("unresolved property [%s]", token.getText()));
                     }
+                    */
                     stringBuilder.append(value);
                     break;
                 }
@@ -232,18 +244,25 @@ public class Resolver {
         for (Token token : tokens) {
             switch (token.getType()) {
                 case PROPERTY: {
-                    String value = properties.get(token.getValue());
+                    String value = properties.getOrDefault(token.getValue(), "");
+                    // Code left in the event that we want to throw an exception if a property is unresolved
+                    /*
                     if (value == null) {
                         throw new ResolverException(format("unresolved property [%s]", token.getText()));
                     }
+                    */
                     stringBuilder.append(value);
                     break;
                 }
                 case ENVIRONMENT_VARIABLE: {
-                    String value = environmentVariables.get(token.getValue());
+                    String value = environmentVariables.getOrDefault(token.getValue(), "");
+                    // Code left in the event that we want to throw an exception if an environment variable is
+                    // unresolved
+                    /*
                     if (value == null) {
                         throw new ResolverException(format("unresolved environment variable [%s]", token.getText()));
                     }
+                    */
                     stringBuilder.append(value);
                     break;
                 }

--- a/tests/all.yaml
+++ b/tests/all.yaml
@@ -43,3 +43,5 @@ pipeline:
           run: $PIPELINER tests/test-timeout-minutes.yaml
         - name: tests/test-pipeliner-variables.yaml
           run: $PIPELINER tests/test-pipeliner-variables.yaml
+        - name: tests/test-unresolved-variables.yaml
+          run: $PIPELINER tests/test-unresolved-variables.yaml

--- a/tests/test-capture-append.yaml
+++ b/tests/test-capture-append.yaml
@@ -9,7 +9,6 @@ pipeline:
       steps:
         - name: step 1
           id: step-1
-          enabled: true
           run: |
             echo "The version is " >> $version.1
             ${{ test.scripts.directory }}/test-arguments-are-equal.sh "${{ version.1 }}" "The version is "
@@ -18,22 +17,18 @@ pipeline:
             ${{ test.scripts.directory }}/test-arguments-are-equal.sh "${{ pipeline-1.job-1.step-1.version.1 }}" "The version is "
         - name: step 2
           id: step-2
-          enabled: true
           run: |
             ${{ test.scripts.directory }}/test-arguments-are-equal.sh "${{ step-1.version.1 }}" "The version is "
             ${{ test.scripts.directory }}/test-arguments-are-equal.sh "${{ job-1.step-1.version.1 }}" "The version is "
             ${{ test.scripts.directory }}/test-arguments-are-equal.sh "${{ pipeline-1.job-1.step-1.version.1 }}" "The version is "
         - name: step 3
           id: step-3
-          enabled: true
           run: ${{ test.scripts.directory }}/test-arguments-are-equal.sh "${{ pipeline-1.job-1.step-1.version.1 }}" "The version is "
         - name: step 4
           id: step-4
-          enabled: true
           run: ./mvnw org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=project.version -q -DforceStdout >> $version.1
         - name: step 5
           id: step-5
-          enabled: true
           run: |
             $PIPELINER --version > $version.2
             ${{ test.scripts.directory }}/test-arguments-are-equal.sh "The version is ${{ version.2 }}" "${{ version.1 }}"
@@ -41,15 +36,12 @@ pipeline:
             ${{ test.scripts.directory }}/test-arguments-are-equal.sh "The version is ${{ pipeline-1.job-1.step-5.version.2 }}" "${{ version.1 }}"
         - name: step 6
           id: step-6
-          enabled: true
           run: echo "Overwritten value" > $version
         - name: step 7
           id: step-7
-          enabled: true
           run: ${{ test.scripts.directory }}/test-arguments-are-equal.sh "${{ version }}" "Overwritten value"
         - name: step 8
           id: my-step
-          enabled: true
           run: |
             echo "test string" > $version.1
             ${{ test.scripts.directory }}/test-arguments-are-equal.sh "test string" "${{ version.1 }}"

--- a/tests/test-extensions-1.yaml
+++ b/tests/test-extensions-1.yaml
@@ -1,6 +1,5 @@
 pipeline:
   name: test-extensions-1
-  enabled: true
   with:
     tests.directory: tests
     tests.scripts.directory: $PIPELINER_HOME/${{ tests.directory}}/scripts

--- a/tests/test-extensions-2.yaml
+++ b/tests/test-extensions-2.yaml
@@ -1,6 +1,5 @@
 pipeline:
   name: test-extensions-1
-  enabled: true
   with:
     tests.directory: tests
     tests.scripts.directory: $PIPELINER_HOME/${{ tests.directory}}/scripts

--- a/tests/test-properties-5.yaml
+++ b/tests/test-properties-5.yaml
@@ -9,7 +9,6 @@ pipeline:
       steps:
         - name: step 1
           id: my-step
-          enabled: true
           run: |
             echo "test string" > $version.1
             ${{ test.scripts.directory }}/test-arguments-are-equal.sh "test string" "${{ version.1 }}"

--- a/tests/test-properties-6.yaml
+++ b/tests/test-properties-6.yaml
@@ -7,23 +7,19 @@ pipeline:
     - name: test-properties-6
       steps:
         - name: step 1
-          enabled: true
           run: |
             ${{ test.scripts.directory }}/test-arguments-are-equal.sh "$PWD" "${{ pwd }}"
         - name: step 2
-          enabled: true
           env:
             FOO: bad
           run: |
             echo $FOO
             ${{ test.scripts.directory }}/test-arguments-are-equal.sh "$FOO" "bad"
         - name: step 3
-          enabled: true
           run: |
             echo ${{ pwd }}
             ${{ test.scripts.directory }}/test-arguments-are-equal.sh "$PWD" "${{ pwd }}"
         - name: step 4
-          enabled: true
           env:
             PROPERTY_1: ${{ property.1 }}
           with:
@@ -32,7 +28,6 @@ pipeline:
             echo $PROPERTY_1 ${{ property.1 }}
             ${{ test.scripts.directory }}/test-arguments-are-equal.sh "$PROPERTY_1" "${{ property.1 }}"
         - name: step 5
-          enabled: true
           env:
             PROPERTY_1: ${{ property.1 }}
             PROPERTY_2: ${{ property.2 }}

--- a/tests/test-properties-7.yaml
+++ b/tests/test-properties-7.yaml
@@ -7,23 +7,19 @@ pipeline:
     - name: test-properties-7
       steps:
         - name: step 1
-          enabled: true
           run: |
             ${{test.scripts.directory}}/test-arguments-are-equal.sh "$PWD" "${{pwd}}"
         - name: step 2
-          enabled: true
           env:
             FOO: bad
           run: |
             echo $FOO
             ${{test.scripts.directory}}/test-arguments-are-equal.sh "$FOO" "bad"
         - name: step 3
-          enabled: true
           run: |
             echo ${{pwd}}
             ${{test.scripts.directory}}/test-arguments-are-equal.sh "$PWD" "${{pwd}}"
         - name: step 4
-          enabled: true
           env:
             PROPERTY_1: ${{property.1}}
           with:
@@ -32,7 +28,6 @@ pipeline:
             echo $PROPERTY_1 ${{property.1}}
             ${{test.scripts.directory}}/test-arguments-are-equal.sh "$PROPERTY_1" "${{property.1}}"
         - name: step 5
-          enabled: true
           env:
             PROPERTY_1: ${{property.1}}
             PROPERTY_2: ${{property.2}}

--- a/tests/test-shells.yaml
+++ b/tests/test-shells.yaml
@@ -1,6 +1,5 @@
 pipeline:
   name: test-shells
-  enabled: true
   jobs:
     - name: test-shells
       steps:

--- a/tests/test-timeout-minutes.yaml
+++ b/tests/test-timeout-minutes.yaml
@@ -1,6 +1,5 @@
 pipeline:
   name: test-timeout-minutes
-  enabled: true
   jobs:
     - name: test-timeout-minutes
       steps:

--- a/tests/test-unresolved-variables.yaml
+++ b/tests/test-unresolved-variables.yaml
@@ -1,0 +1,19 @@
+pipeline:
+  name: test-not-defined
+  with:
+    test.scripts.directory: $PIPELINER_HOME/tests/scripts
+  jobs:
+    - name: test-not-defined-job
+      steps:
+        - name: step-1
+          with:
+            foo: ${{ bar }}
+          run: |
+            echo "${{ foo }}"
+            ${{ test.scripts.directory }}/test-arguments-are-equal.sh "${{ foo }}" ""
+            echo "${{bar}}"
+            ${{ test.scripts.directory }}/test-arguments-are-equal.sh "${{bar}}" ""
+            echo $FOO
+            ${{ test.scripts.directory }}/test-arguments-are-equal.sh "$FOO" ""
+            echo ${BAR}
+            ${{ test.scripts.directory }}/test-arguments-are-equal.sh "${BAR}" ""


### PR DESCRIPTION
Prior versions of Pipeliner would generate an error if a property or environment variables was referenced...

```
foo ${{ foo }} bar $BAR
```

This PR changes the behavior to be more like GitHub Actions and return an empty string for unresolved properties and environment variables.

This allows using a Bash command to check for a property or environment variable...

Example:

```
pipeline:
  name: release
  jobs:
    - name: release
      enabled: true
      steps:
        - name: check for release property
          run: if [ -z "${{ release }}" ]; then echo "release property is required, exiting" && exit 1; fi
```
