### PR TITLE
Fixed empty property declaration edge case to treat it as a text

### DIFF
--- a/src/main/java/org/verifyica/pipeliner/tokenizer/DeveloperDebug.java
+++ b/src/main/java/org/verifyica/pipeliner/tokenizer/DeveloperDebug.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2025-present Pipeliner project authors and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.verifyica.pipeliner.tokenizer;
+
+/** Class to implement DeveloperDebug */
+public class DeveloperDebug {
+
+    /** Flag to enable developer debugging */
+    public static final boolean isEnabled = false;
+
+    /** Constructor */
+    private DeveloperDebug() {
+        // INTENTIONALLY BLANK
+    }
+}

--- a/src/main/java/org/verifyica/pipeliner/tokenizer/Tokenizer.java
+++ b/src/main/java/org/verifyica/pipeliner/tokenizer/Tokenizer.java
@@ -32,7 +32,7 @@ import org.verifyica.pipeliner.tokenizer.lexer.TokenizerParser;
 public class Tokenizer {
 
     // Local debugging flag, probably should be using a logger
-    private static final boolean DEVELOPER_DEBUG = false;
+    private static final boolean DEVELOPER_DEBUG = DeveloperDebug.isEnabled;
 
     /** Constructor */
     private Tokenizer() {

--- a/src/test/java/org/verifyica/pipeliner/tokenizer/TokenizerTest.java
+++ b/src/test/java/org/verifyica/pipeliner/tokenizer/TokenizerTest.java
@@ -43,12 +43,12 @@ import org.junit.jupiter.params.provider.MethodSource;
 public class TokenizerTest {
 
     /**
-     * Method to test the tokenizer, validating the tokens equal the expected tokens
+     * Method to test the tokenizer, validating the token list returned is equal the expected token list
      *
      * @param testData the test data
      * @throws TokenizerException If an error occurs during tokenization
      */
-    @ParameterizedTest(name = "{0}")
+    @ParameterizedTest
     @MethodSource("getTestData")
     public void testTokenizer(TestData testData) throws TokenizerException {
         List<Token> tokens = Tokenizer.tokenize(testData.getInput());
@@ -294,11 +294,16 @@ public class TokenizerTest {
                         Token.Type.TEXT,
                         "cat file.txt | tr '[:lower:]' '[:upper:]'",
                         "cat file.txt | tr '[:lower:]' '[:upper:]'")));
+
+        list.add(new TestData()
+                .input("sed 's/\\${{}}/X/g' file")
+                .addExpectedToken(new Token(Token.Type.TEXT, "sed 's/\\${{}}/X/g' file", "sed 's/\\${{}}/X/g' file")));
+
         return list.stream();
     }
 
     /**
-     * Method to test the tokenizer
+     * Method to test the tokenizer, but not validate the token list
      *
      * @throws TokenizerException If an error occurs during tokenization
      */
@@ -314,8 +319,6 @@ public class TokenizerTest {
                 throw new FileNotFoundException(format("resource [%s] not found", resourceName));
             }
 
-            long counter = 0;
-
             try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(inputStream))) {
                 while (true) {
                     String line = bufferedReader.readLine();
@@ -329,12 +332,8 @@ public class TokenizerTest {
                     }
 
                     assertThatNoException().isThrownBy(() -> Tokenizer.validate(line));
-
-                    counter++;
                 }
             }
-
-            System.out.printf("processed [%d] lines%n", counter);
         } finally {
             if (inputStream != null) {
                 inputStream.close();
@@ -345,7 +344,7 @@ public class TokenizerTest {
     /** Class to implement TestData */
     public static class TestData {
 
-        private String inputString;
+        private String input;
         private final List<Token> expectedTokens;
 
         /** Constructor */
@@ -360,21 +359,42 @@ public class TokenizerTest {
          * @return the TestData
          */
         public TestData input(String input) {
-            this.inputString = input;
+            this.input = input;
             return this;
         }
 
+        /**
+         * Method to get the input
+         *
+         * @return the input
+         */
         public String getInput() {
-            return inputString;
+            return input;
         }
 
+        /**
+         * Method to add an expected token
+         *
+         * @param token token
+         * @return the TestData
+         */
         public TestData addExpectedToken(Token token) {
             this.expectedTokens.add(token);
             return this;
         }
 
+        /**
+         * Method to get the expected tokens
+         *
+         * @return the expected tokens
+         */
         public List<Token> getExpectedTokens() {
             return expectedTokens;
+        }
+
+        @Override
+        public String toString() {
+            return input;
         }
     }
 }


### PR DESCRIPTION
For a string...

`"sed 's/\\${{}}/X/g' file`

... the current Antlr grammar treats it as 3 tokens...

TEXT -> `"sed 's/\\`
PROPERTY -> `${{}}`
TEXT -> `/X/g' file`

Since `${{}}` isn't a valid property, we convert it to TEXT token.