### PR TITLE
Fixed extra spaces when using line continuations

### DIFF
--- a/src/main/java/org/verifyica/pipeliner/common/MultiLineMerger.java
+++ b/src/main/java/org/verifyica/pipeliner/common/MultiLineMerger.java
@@ -46,17 +46,31 @@ public class MultiLineMerger {
 
         StringBuilder current = new StringBuilder();
 
-        for (String string : lines) {
-            if (string.endsWith(" \\")) {
-                current.append(string, 0, string.length() - 1);
+        for (String line : lines) {
+            if (line.endsWith(" \\")) {
+                // Line continuation
+
+                // Remove the trailing backslash and any whitespace
+                String trimmedLine = line.substring(0, line.length() - 2);
+
+                // Check if the line is a comment
+                if (!trimmedLine.trim().startsWith("#")) {
+                    // Append the trimmed line to the current line
+                    current.append(trimmedLine);
+                }
             } else {
+                // Line is not a continuation
+
+                // If the current line is not empty
                 if (current.length() > 0) {
-                    current.append(" ");
-                    current.append(string.trim());
+                    // current.append(" ");
+                    current.append(line);
                     result.add(current.toString().trim());
+
+                    // Reset the current line
                     current.setLength(0);
                 } else {
-                    result.add(string);
+                    result.add(line);
                 }
             }
         }

--- a/tests/test-commands.yaml
+++ b/tests/test-commands.yaml
@@ -11,10 +11,10 @@ pipeline:
         - name: test-2
           run: |
             ls \
-              | grep "src"
+             | grep "src"
         - name: test-3
           run: |
             ls \
-              | grep "src"            
+             | grep "src"            
             ls \
-              | grep "examples"
+            | grep "examples"


### PR DESCRIPTION
When using line continuations are used in a `run:` command, the space in ' \' was being added. This is inconsistent with Bash behavior.

Add support for comments in line continuations. If a line starts with `#` the line is considered a comment and stripped out.

Example:

```yaml
        - name: test-2
          run: |
            ls \
             # This is a comment \
             | grep "src"
```

The command will be `ls | grep "src"`
