### PR TITLE
Refactored IPC file format

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,21 +323,33 @@ The example and test pipelines provide other examples...
 
 # Pipeliner IPC
 
-For more complex scenarios, where you need to pass properties and capture properties, you can use Pipeliner IPC.
+For more complex scenarios, where you need to pass multiple properties and capture multiple properties, you can use Pipeliner IPC.
 
 Pipeliner creates two temporary files. The filenames are passed to the application as environment variables.
 
 - `PIPELINER_IPC_IN`
 - `PIPELINER_IPC_OUT` 
 
+#### File Format
+
+For a property and value...
+
+- `test.property` with a value of `test.value`
+
+The `PIPELINER_IPC_IN` and/or `PIPELINER_IPC_OUT` file contents would be...
+
+- `test.property=dGVzdC52YWx1ZQ==`
+
+For empty properties...
+
+- `test.property=`
+
 **Notes**
 
-- The properties file use a `name=value` format
-  - property names must match the regular expression `^[a-zA-Z0-9-_][a-zA-Z0-9-_.]*[a-zA-Z0-9-_]$`
-  - values are escaped...
-    - '\\' is escaped as '\\\\'
-    - '\r' is escaped as '\\\r'
-    - '\n' is escaped as '\\\n'
+- Property name must match the regular expression `[a-zA-Z0-9-_][a-zA-Z0-9-_.]*[a-zA-Z0-9-_]`
+
+
+- The properties file use a `name=BASE64(value)` format
   - lines starting with `#` are ignored
   - empty lines are ignored
 
@@ -355,12 +367,24 @@ Write to this properties file to capture properties.
 
 ### Example
 
-- example IPC pipeline [examples/ipc.yaml](examples/ipc.yaml)
-  - uses a class `Extension` packaged in the jar as an example
+Example IPC pipelines [examples/ipc](examples/ipc)
+
+Functional examples for the following languages...
+  - Bash script
+  - Go
+  - Groovy
+  - Java
+  - JavaScript
+  - Kotlin
+  - Python
+  - Rust
+
+**Notes**
+
+- The IPC examples are disabled by default
 
 
-- additional examples in other languages
-  - [examples/ipc](examples/ipc)
+- The IPC examples are functional, but should not be considered production quality code
 
 ## Executing
 

--- a/examples/extensions/build-and-run-extensions.yaml
+++ b/examples/extensions/build-and-run-extensions.yaml
@@ -1,6 +1,7 @@
 #
 # Disabled by default
 #
+# Bash is most likely installed, but we disable it
 # Go may not be installed
 # Groovy may not be installed
 # Java is installed, but we disable it
@@ -23,6 +24,7 @@ pipeline:
             rm -Rf ${{ temporary.directory }}/*
         - name: copy extension source
           run: |
+            cp -r ${{ examples.ipc.directory }}/bash ${{ temporary.directory }}/bash
             cp -r ${{ examples.ipc.directory }}/go ${{ temporary.directory }}/go
             cp -r ${{ examples.ipc.directory }}/groovy ${{ temporary.directory }}/groovy
             cp -r ${{ examples.ipc.directory }}/java ${{ temporary.directory }}/java
@@ -30,6 +32,15 @@ pipeline:
             cp -r ${{ examples.ipc.directory }}/kotlin ${{ temporary.directory }}/kotlin
             cp -r ${{ examples.ipc.directory }}/python ${{ temporary.directory }}/python
             cp -r ${{ examples.ipc.directory }}/rust ${{ temporary.directory }}/rust
+        - name: build-bash-extension
+          working-directory: ${{ temporary.directory }}/bash
+          run: |
+            rm -Rf *.yaml
+            cp extension.sh run.sh
+            zip -qr ../bash-extension.zip .
+            sha1sum ../bash-extension.zip | awk '{print $1}' > $bash.extension.sha1.checksum
+            sha256sum ../bash-extension.zip | awk '{print $1}' > $bash.extension.sha256.checksum
+            sha512sum ../bash-extension.zip | awk '{print $1}' > $bash.extension.sha512.checksum
         - name: build-go-extension
           working-directory: ${{ temporary.directory }}/go
           run: |
@@ -120,6 +131,7 @@ pipeline:
         - name: run extensions 1
           working-directory: ${{ temporary.directory }}
           run: |
+            --extension ./bash-extension.zip
             --extension ./go-extension.zip
             --extension ./groovy-extension.zip
             --extension ./java-extension.zip
@@ -132,6 +144,7 @@ pipeline:
         - name: run extensions 2
           working-directory: ${{ temporary.directory }}
           run: |
+            --extension bash-extension.zip
             --extension go-extension.zip
             --extension groovy-extension.zip
             --extension java-extension.zip
@@ -144,6 +157,7 @@ pipeline:
         - name: run extensions 3
           working-directory: ${{ temporary.directory }}
           run: |
+            --extension file://./bash-extension.zip
             --extension file://./go-extension.zip
             --extension file://./groovy-extension.zip
             --extension file://./java-extension.zip
@@ -156,6 +170,7 @@ pipeline:
         - name: run extensions 4
           working-directory: ${{ temporary.directory }}
           run: |
+            --extension file://bash-extension.zip
             --extension file://go-extension.zip
             --extension file://groovy-extension.zip
             --extension file://java-extension.zip
@@ -168,6 +183,9 @@ pipeline:
         - name: run extensions 5
           working-directory: ${{ temporary.directory }}
           run: |
+            --extension ./bash-extension.zip ${{ bash.extension.sha1.checksum }}
+            --extension ./bash-extension.zip ${{ bash.extension.sha256.checksum }}
+            --extension ./bash-extension.zip ${{ bash.extension.sha512.checksum }}
             --extension ./go-extension.zip ${{ go.extension.sha1.checksum }}
             --extension ./go-extension.zip ${{ go.extension.sha256.checksum }}
             --extension ./go-extension.zip ${{ go.extension.sha512.checksum }}
@@ -194,6 +212,9 @@ pipeline:
         - name: run extensions 6
           working-directory: ${{ temporary.directory }}
           run: |
+            --extension bash-extension.zip ${{ bash.extension.sha1.checksum }}
+            --extension bash-extension.zip ${{ bash.extension.sha256.checksum }}
+            --extension bash-extension.zip ${{ bash.extension.sha512.checksum }}
             --extension go-extension.zip ${{ go.extension.sha1.checksum }}
             --extension go-extension.zip ${{ go.extension.sha256.checksum }}
             --extension go-extension.zip ${{ go.extension.sha512.checksum }}
@@ -220,6 +241,9 @@ pipeline:
         - name: run extensions 7
           working-directory: ${{ temporary.directory }}
           run: |
+            --extension file://./bash-extension.zip ${{ bash.extension.sha1.checksum }}
+            --extension file://./bash-extension.zip ${{ bash.extension.sha256.checksum }}
+            --extension file://./bash-extension.zip ${{ bash.extension.sha512.checksum }}
             --extension file://./go-extension.zip ${{ go.extension.sha1.checksum }}
             --extension file://./go-extension.zip ${{ go.extension.sha256.checksum }}
             --extension file://./go-extension.zip ${{ go.extension.sha512.checksum }}
@@ -246,6 +270,9 @@ pipeline:
         - name: run extensions 8
           working-directory: ${{ temporary.directory }}
           run: |
+            --extension file://bash-extension.zip ${{ bash.extension.sha1.checksum }}
+            --extension file://bash-extension.zip ${{ bash.extension.sha256.checksum }}
+            --extension file://bash-extension.zip ${{ bash.extension.sha512.checksum }}            
             --extension file://go-extension.zip ${{ go.extension.sha1.checksum }}
             --extension file://go-extension.zip ${{ go.extension.sha256.checksum }}
             --extension file://go-extension.zip ${{ go.extension.sha512.checksum }}

--- a/examples/ipc/all.yaml
+++ b/examples/ipc/all.yaml
@@ -1,6 +1,7 @@
 #
 # Disabled by default
 #
+# Bash is most likely installed, but we disable it
 # Go may not be installed
 # Groovy may not be installed
 # Java is installed, but we disable it
@@ -14,6 +15,8 @@ pipeline:
   jobs:
     - name: all
       steps:
+        - name: examples/ipc/bash/bash-extension.yaml
+          run: $PIPELINER examples/ipc/bash/bash-extension.yaml
         - name: examples/ipc/go/go-extension.yaml
           run: $PIPELINER examples/ipc/go/go-extension.yaml
         - name: examples/ipc/groovy/groovy-extension.yaml

--- a/examples/ipc/bash/README.md
+++ b/examples/ipc/bash/README.md
@@ -1,0 +1,13 @@
+# Go Extension
+
+This code implements a pipeline and an extension using a Bash script and Pipeliner IPC.
+
+## Example
+
+```shell
+./pipeliner examples/ipc/bash/bash-extension.yaml
+```
+
+---
+
+Copyright (C) 2025-present Pipeliner project authors and contributors

--- a/examples/ipc/bash/bash-extension.yaml
+++ b/examples/ipc/bash/bash-extension.yaml
@@ -1,0 +1,15 @@
+pipeline:
+  name: Hello World Bash Pipeline
+  jobs:
+    - name: Hello World Bash Job
+      working-directory: examples/ipc/bash
+      steps:
+        - name: Hello World Bash Step
+          shell: none
+          with:
+            name: User
+          run: extension.sh
+        - name: Hello World Bash Captured Properties
+          run: |
+            echo captured extension property \${{ extension.property.1 }} = "${{ extension.property.1 }}"
+            echo captured extension property \${{ extension.property.2 }} = "${{ extension.property.2 }}"

--- a/examples/ipc/bash/extension.sh
+++ b/examples/ipc/bash/extension.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2025-present Pipeliner project authors and contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# This is AI generated code
+#
+
+# Check if the input file is specified and exists
+if [[ -z "$PIPELINER_IPC_IN" || ! -f "$PIPELINER_IPC_IN" ]]; then
+    echo "Error: PIPELINER_IPC_IN is not set or the file does not exist."
+    exit 1
+fi
+
+echo "PIPELINER_IPC_IN file [$PIPELINER_IPC_IN]"
+
+# Declare an associative array
+declare -A ipc_in_properties
+
+# Read the file line by line
+while IFS= read -r line; do
+    # Skip empty lines and lines without '='
+    if [[ -z "$line" || "$line" != *"="* ]]; then
+        continue
+    fi
+
+    # Split the line into key and value on the first "="
+    key="${line%%=*}"
+    encoded_value="${line#*=}"
+
+    # Check if encoded_value is empty
+    if [[ -z "$encoded_value" ]]; then
+        decoded_value=""
+    else
+        # Decode the value from Base64
+        decoded_value=$(echo "$encoded_value" | base64 --decode)
+    fi
+
+    # Store the key and decoded value in the associative array
+    ipc_in_properties["$key"]="$decoded_value"
+
+done < "$PIPELINER_IPC_IN"
+
+# Output the associative array for debugging or demonstration
+for key in "${!ipc_in_properties[@]}"; do
+    echo "PIPELINER_IPC_IN property [$key] = [${ipc_in_properties[$key]}]"
+done
+
+echo "This is a sample Bash extension"
+
+# Check if the output file is specified
+if [[ -z "$PIPELINER_IPC_OUT" || ! -f "$PIPELINER_IPC_OUT" ]]; then
+    echo "Error: PIPELINER_IPC_OUT is not set."
+    exit 1
+fi
+
+# Example associative array (replace with your array)
+declare -A ipc_out_properties=(
+    ["extension.property.1"]="bash.extension.foo"
+    ["extension.property.2"]="bash.extension.bar"
+)
+
+echo "PIPELINER_IPC_OUT file [$PIPELINER_IPC_OUT]"
+
+# Write the associative array to the output file with Base64-encoded values
+for key in "${!ipc_out_properties[@]}"; do
+    value="${ipc_out_properties[$key]}"
+
+    # Base64 encode the value
+    encoded_value=$(echo -n "$value" | base64)
+
+    echo "PIPELINER_IPC_OUT property [$key] = [$value]"
+
+    # Write the key and Base64-encoded value to the file
+    echo "$key=$encoded_value" >>  "$PIPELINER_IPC_OUT"
+done

--- a/examples/ipc/go/README.md
+++ b/examples/ipc/go/README.md
@@ -2,15 +2,7 @@
 
 This code implements a pipeline and an extension using Go and Pipeliner IPC.
 
-## Build
-
-```shell
-cd examples/ipc/go
-go build extension.go
-cd ../../../.
-```
-
-## Usage
+## Example
 
 ```shell
 ./pipeliner examples/ipc/go/go-extension.yaml

--- a/examples/ipc/groovy/README.md
+++ b/examples/ipc/groovy/README.md
@@ -2,7 +2,7 @@
 
 This code implements a pipeline and an extension using Groovy and Pipeliner IPC.
 
-## Usage
+## Example
 
 ```shell
 ./pipeliner examples/ipc/groovy/groovy-extension.yaml

--- a/examples/ipc/java/README.md
+++ b/examples/ipc/java/README.md
@@ -2,15 +2,7 @@
 
 This code implements a pipeline and an extension using Java and Pipeliner IPC.
 
-## Build
-
-```shell
-cd examples/ipc/java
-javac Extension.java
-cd ../../../.
-```
-
-## Usage
+## Example
 
 ```shell
 ./pipeliner examples/ipc/java/java-extension.yaml

--- a/examples/ipc/js/README.md
+++ b/examples/ipc/js/README.md
@@ -2,7 +2,7 @@
 
 This code implements a pipeline and an extension using Node / JavaScript and Pipeliner IPC.
 
-## Usage
+## Example
 
 ```shell
 ./pipeliner examples/ipc/js/js-extension.yaml

--- a/examples/ipc/kotlin/README.md
+++ b/examples/ipc/kotlin/README.md
@@ -2,15 +2,7 @@
 
 This code implements a pipeline and an extension using Kotlin and Pipeliner IPC.
 
-## Build
-
-```shell
-cd examples/ipc/kotlin
-kotlin Extension.kt
-cd ../../../.
-```
-
-## Usage
+## Example
 
 ```shell
 ./pipeliner examples/ipc/kotlin/kotlin-extension.yaml

--- a/examples/ipc/python/README.md
+++ b/examples/ipc/python/README.md
@@ -2,7 +2,7 @@
 
 This code implements a pipeline and an extension using Python and Pipeliner IPC.
 
-## Usage
+## Example
 
 ```shell
 ./pipeliner examples/ipc/python/python-extension.yaml

--- a/examples/ipc/rust/README.md
+++ b/examples/ipc/rust/README.md
@@ -2,7 +2,7 @@
 
 This code implements a pipeline and an extension using Rust and Pipeliner IPC.
 
-## Usage
+## Example
 
 ```shell
 ./pipeliner examples/ipc/rust/rust-extension.yaml


### PR DESCRIPTION
Refactored IPC file format.

---

For complex scenarios, where you need to pass multiple properties and capture multiple properties, you can use Pipeliner IPC.

Pipeliner creates two temporary files. The filenames are passed to the application as environment variables.

- `PIPELINER_IPC_IN`
- `PIPELINER_IPC_OUT` 

#### File Format

For a property and value...

- `test.property` with a value of `test.value`

The `PIPELINER_IPC_IN` and/or `PIPELINER_IPC_OUT` file contents would be...

- `test.property=dGVzdC52YWx1ZQ==`

For empty properties...

- `test.property=`

**Notes**

- Property name must match the regular expression `[a-zA-Z0-9-_][a-zA-Z0-9-_.]*[a-zA-Z0-9-_]`


- The properties file use a `name=BASE64(value)` format
  - lines starting with `#` are ignored
  - empty lines are ignored