### PR TITLE
Refactored Pipeliner IPC file format

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,20 +342,20 @@ For a variable name and value...
 
 The `PIPELINER_IPC_IN` and/or `PIPELINER_IPC_OUT` file contents would be...
 
-- `test.property=dGVzdC52YWx1ZQ==`
+- `dGVzdC5wcm9wZXJ0eQ== dGVzdC52YWx1ZQ==`
 
 For empty variables...
 
-- `test.property=`
+- `dGVzdC5wcm9wZXJ0eQ==`
 
 **Notes**
 
 - A property must match the regular expression `[a-zA-Z0-9-_][a-zA-Z0-9-_.]*[a-zA-Z0-9-_]`
 
 
-- The IPC file use a `name=BASE64(value)` format
+- The IPC file use a `BASE64(name) BASE64(value)` format
   - lines starting with `#` are ignored
-  - lines that effectively empty are ignored
+  - lines that are empty after being trimmed are ignored
 
 ### PIPELINER_IPC_IN
 

--- a/examples/extensions/build-and-run-extensions.yaml
+++ b/examples/extensions/build-and-run-extensions.yaml
@@ -66,7 +66,7 @@ pipeline:
             rm -Rf TMP
             echo "#/bin/bash" > run.sh
             echo "" >> run.sh
-            echo "./extension" >> run.sh
+            echo "./extension" >> run.shf
             zip -qr ../c#-extension.zip .
             sha1sum ../c#-extension.zip | awk '{print $1}' > $csharp_extension_sha1_checksum
             sha256sum ../c#-extension.zip | awk '{print $1}' > $csharp_extension_sha256_checksum

--- a/examples/ipc/all.yaml
+++ b/examples/ipc/all.yaml
@@ -19,6 +19,7 @@ pipeline:
     - name: all
       steps:
         - name: examples/ipc/bash/bash-extension.yaml
+          enabled: false
           run: $PIPELINER examples/ipc/bash/bash-extension.yaml
         - name: examples/ipc/c#/c#-extension.yaml
           run: $PIPELINER examples/ipc/c#/c#-extension.yaml

--- a/examples/ipc/js/extension.js
+++ b/examples/ipc/js/extension.js
@@ -47,16 +47,19 @@ for (const line of lines) {
   // Skip empty lines and lines without '='
   if (!line.trim() || !line.includes('=')) continue;
 
-  // Split the line into key and value
-  const [key, encodedValue = ''] = line.split('=', 2);
+  // Split the line into name and value
+  const [encodedName, encodedValue = ''] = line.split(' ', 2);
+
+  // Decode the Base64 name
+  const name = Buffer.from(encodedName, 'base64').toString('utf8')
 
   // Decode the Base64 value
-  const decodedValue = encodedValue
+  const value = encodedValue
     ? Buffer.from(encodedValue, 'base64').toString('utf8')
     : '';
 
   // Add to the object
-  ipcInProperties[key] = decodedValue;
+  ipcInProperties[name] = value;
 }
 
 // Debug output for the object
@@ -83,12 +86,14 @@ for (const [key, value] of Object.entries(ipcOutProperties)) {
   try {
     console.log(`PIPELINER_IPC_OUT property [${key}] = [${value}]`);
 
+    const encodedName = Buffer.from(key, 'utf8').toString('base64');
+
     const encodedValue = value
       ? Buffer.from(value, 'utf8').toString('base64')
       : '';
 
     // Write the key-value pair to the array
-    outputLines.push(`${key}=${encodedValue}`);
+    outputLines.push(`${encodedName} ${encodedValue}`);
   } catch (error) {
     console.error(`Error processing property [${key}]: ${error.message}`);
   }

--- a/src/main/java/org/verifyica/pipeliner/Constants.java
+++ b/src/main/java/org/verifyica/pipeliner/Constants.java
@@ -41,19 +41,19 @@ public class Constants {
     public static final String PIPELINER_TMP = "PIPELINER_TMP";
 
     /** Constant */
-    public static final String PIPELINER_IPC = "PIPELINER_IPC";
+    public static final String PIPELINER_IPC_IN = "PIPELINER_IPC_IN";
 
     /** Constant */
-    public static final String PIPELINER_IPC_IN = "PIPELINER_IPC_IN";
+    public static final String PIPELINER_IPC_IN_FILE_PREFIX = "pipeliner-ipc-in-";
 
     /** Constant */
     public static final String PIPELINER_IPC_OUT = "PIPELINER_IPC_OUT";
 
     /** Constant */
-    public static final String PIPELINER_DISABLE_SHUTDOWN_HOOK = "PIPELINER_DISABLE_SHUTDOWN_HOOK";
+    public static final String PIPELINER_IPC_OUT_FILE_PREFIX = "pipeliner-ipc-out-";
 
     /** Constant */
-    public static final String PIPELINER_DISABLE_SHUTDOWN_HOOKS = "PIPELINER_DISABLE_SHUTDOWN_HOOKS";
+    public static final String PIPELINER_SHUTDOWN_HOOKS_ENABLED = "PIPELINER_SHUTDOWN_HOOKS_ENABLED";
 
     /** Constant */
     public static final String PIPELINER_LOG_LEVEL = "PIPELINER_LOG_LEVEL";
@@ -75,6 +75,9 @@ public class Constants {
 
     /** Constant */
     public static final String PIPELINER_MASK_VARIABLES = "pipeliner_mask_variables";
+
+    /** Constant */
+    public static final String DEFAULT_WORKING_DIRECTORY = ".";
 
     /** Constant */
     public static final String SCOPE_SEPARATOR = ".";

--- a/src/main/java/org/verifyica/pipeliner/common/ArchiveExtractor.java
+++ b/src/main/java/org/verifyica/pipeliner/common/ArchiveExtractor.java
@@ -120,7 +120,7 @@ public class ArchiveExtractor {
      */
     private static Path extractZip(Path file) throws IOException {
         Path archiveDirectory = Files.createTempDirectory(TEMPORARY_DIRECTORY_ZIP);
-        ShutdownHook.deleteOnExit(archiveDirectory);
+        ShutdownHooks.deleteOnExit(archiveDirectory);
         setPermissions(archiveDirectory);
 
         if (LOGGER.isTraceEnabled()) {
@@ -164,7 +164,7 @@ public class ArchiveExtractor {
      */
     private static Path extractTarGz(Path file) throws IOException {
         Path archiveDirectory = Files.createTempDirectory(TEMPORARY_DIRECTORY_TAR_GZ);
-        ShutdownHook.deleteOnExit(archiveDirectory);
+        ShutdownHooks.deleteOnExit(archiveDirectory);
         setPermissions(archiveDirectory);
 
         if (LOGGER.isTraceEnabled()) {

--- a/src/main/java/org/verifyica/pipeliner/common/Downloader.java
+++ b/src/main/java/org/verifyica/pipeliner/common/Downloader.java
@@ -102,7 +102,7 @@ public class Downloader {
         String lowerCaseUrl = url.toLowerCase(Locale.ROOT);
         Path archiveFile = Files.createTempFile(TEMPORARY_DIRECTORY_PREFIX, TEMPORARY_DIRECTORY_SUFFIX);
         Files.setPosixFilePermissions(archiveFile, PERMISSIONS);
-        ShutdownHook.deleteOnExit(archiveFile);
+        ShutdownHooks.deleteOnExit(archiveFile);
 
         if (LOGGER.isTraceEnabled()) {
             LOGGER.trace("file [%s]", archiveFile);

--- a/src/main/java/org/verifyica/pipeliner/core/Job.java
+++ b/src/main/java/org/verifyica/pipeliner/core/Job.java
@@ -21,6 +21,7 @@ import static java.lang.String.format;
 import java.util.ArrayList;
 import java.util.List;
 import org.verifyica.pipeliner.Console;
+import org.verifyica.pipeliner.Constants;
 import org.verifyica.pipeliner.logger.Logger;
 import org.verifyica.pipeliner.logger.LoggerFactory;
 
@@ -104,11 +105,18 @@ public class Job extends Node {
 
                 if (jobId != null) {
                     // Add the job scoped variable
-                    context.getWith().put(jobId + SCOPE_SEPARATOR + name, value);
+                    context.getWith().put(jobId + Constants.SCOPE_SEPARATOR + name, value);
 
                     if (pipelineId != null) {
                         // Add the pipeline + job scoped variable
-                        context.getWith().put(pipelineId + SCOPE_SEPARATOR + jobId + SCOPE_SEPARATOR + name, value);
+                        context.getWith()
+                                .put(
+                                        pipelineId
+                                                + Constants.SCOPE_SEPARATOR
+                                                + jobId
+                                                + Constants.SCOPE_SEPARATOR
+                                                + name,
+                                        value);
                     }
                 }
             });

--- a/src/main/java/org/verifyica/pipeliner/core/Node.java
+++ b/src/main/java/org/verifyica/pipeliner/core/Node.java
@@ -28,16 +28,6 @@ import org.verifyica.pipeliner.parser.Parser;
 /** Class to implement Node */
 public abstract class Node {
 
-    /**
-     * Constant for scope separator
-     */
-    public static final String SCOPE_SEPARATOR = Constants.SCOPE_SEPARATOR;
-
-    /**
-     * Constant for default working directory
-     */
-    protected static final String DEFAULT_WORKING_DIRECTORY = ".";
-
     private static final int MIN_TIMEOUT_MINUTES = 1;
 
     private static final int DEFAULT_TIMEOUT_MINUTES = 360;
@@ -323,14 +313,19 @@ public abstract class Node {
     protected void validateEnv() {
         Logger logger = getLogger();
 
-        Map<String, String> envMap = getEnv();
+        Map<String, String> env = getEnv();
 
         if (logger.isTraceEnabled()) {
             logger.trace("validating env ...");
         }
 
-        if (!envMap.isEmpty()) {
-            envMap.forEach((name, value) -> {
+        if (!env.isEmpty()) {
+            if (env.containsKey(Constants.PWD)) {
+                throw new PipelineDefinitionException(
+                        format("%s -> env=[%s] is a reserved environment variable", this, Constants.PWD));
+            }
+
+            env.forEach((name, value) -> {
                 if (logger.isTraceEnabled()) {
                     logger.trace("validating environment variable [%s] = [%s]", name, value);
                 }
@@ -364,14 +359,14 @@ public abstract class Node {
     protected void validateWith() {
         Logger logger = getLogger();
 
-        Map<String, String> withMap = getWith();
+        Map<String, String> with = getWith();
 
         if (logger.isTraceEnabled()) {
             logger.trace("validating with ...");
         }
 
-        if (!withMap.isEmpty()) {
-            withMap.forEach((name, value) -> {
+        if (!with.isEmpty()) {
+            with.forEach((name, value) -> {
                 if (logger.isTraceEnabled()) {
                     logger.trace("validating variable [%s] = [%s]", name, value);
                 }

--- a/src/main/java/org/verifyica/pipeliner/core/Pipeline.java
+++ b/src/main/java/org/verifyica/pipeliner/core/Pipeline.java
@@ -23,6 +23,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import org.verifyica.pipeliner.Console;
+import org.verifyica.pipeliner.Constants;
 import org.verifyica.pipeliner.logger.Logger;
 import org.verifyica.pipeliner.logger.LoggerFactory;
 
@@ -97,7 +98,7 @@ public class Pipeline extends Node {
 
                 if (getId() != null) {
                     // Add the pipeline scoped variable
-                    context.getWith().put(getId() + SCOPE_SEPARATOR + name, value);
+                    context.getWith().put(getId() + Constants.SCOPE_SEPARATOR + name, value);
                 }
             });
 

--- a/src/main/java/org/verifyica/pipeliner/core/Step.java
+++ b/src/main/java/org/verifyica/pipeliner/core/Step.java
@@ -129,22 +129,25 @@ public class Step extends Node {
 
                 if (stepId != null) {
                     // Add the step scoped variable
-                    context.getWith().put(stepId + SCOPE_SEPARATOR + name, value);
+                    context.getWith().put(stepId + Constants.SCOPE_SEPARATOR + name, value);
 
                     if (jobId != null) {
                         // Add the job + step scoped variable
-                        context.getWith().put(jobId + SCOPE_SEPARATOR + stepId + SCOPE_SEPARATOR + name, value);
+                        context.getWith()
+                                .put(
+                                        jobId + Constants.SCOPE_SEPARATOR + stepId + Constants.SCOPE_SEPARATOR + name,
+                                        value);
 
                         if (pipelineId != null) {
                             // Add the pipeline + job + step scoped variable
                             context.getWith()
                                     .put(
                                             pipelineId
-                                                    + SCOPE_SEPARATOR
+                                                    + Constants.SCOPE_SEPARATOR
                                                     + jobId
-                                                    + SCOPE_SEPARATOR
+                                                    + Constants.SCOPE_SEPARATOR
                                                     + stepId
-                                                    + SCOPE_SEPARATOR
+                                                    + Constants.SCOPE_SEPARATOR
                                                     + name,
                                             value);
                         }

--- a/src/main/java/org/verifyica/pipeliner/core/command/ExtensionCommand.java
+++ b/src/main/java/org/verifyica/pipeliner/core/command/ExtensionCommand.java
@@ -31,6 +31,7 @@ import org.verifyica.pipeliner.Console;
 import org.verifyica.pipeliner.Constants;
 import org.verifyica.pipeliner.Environment;
 import org.verifyica.pipeliner.common.QuotedStringTokenizer;
+import org.verifyica.pipeliner.common.ShutdownHooks;
 import org.verifyica.pipeliner.core.Context;
 import org.verifyica.pipeliner.core.Job;
 import org.verifyica.pipeliner.core.Pipeline;
@@ -136,10 +137,10 @@ public class ExtensionCommand implements Command {
             String checksum = tokens.size() == 3 ? tokens.get(2) : null;
 
             // Create the IPC in file
-            ipcInFile = Ipc.createFile();
+            ipcInFile = Ipc.createFile(Constants.PIPELINER_IPC_IN_FILE_PREFIX);
 
             // Create the IPC out file
-            ipcOutFile = Ipc.createFile();
+            ipcOutFile = Ipc.createFile(Constants.PIPELINER_IPC_OUT_FILE_PREFIX);
 
             // Set the IPC environment variable
             environmentVariables.put(Constants.PIPELINER_IPC_IN, ipcInFile.getAbsolutePath());
@@ -266,11 +267,13 @@ public class ExtensionCommand implements Command {
             // Set the exit code to 1 to indicate an error
             exitCode = 1;
         } finally {
-            // Proactively cleanup the IPC in file
-            Ipc.cleanup(ipcInFile);
+            if (ShutdownHooks.areEnabled()) {
+                // Proactively cleanup the IPC in file
+                Ipc.cleanup(ipcInFile);
 
-            // Proactively cleanup the IPC out file
-            Ipc.cleanup(ipcOutFile);
+                // Proactively cleanup the IPC out file
+                Ipc.cleanup(ipcOutFile);
+            }
         }
 
         return exitCode;
@@ -295,7 +298,7 @@ public class ExtensionCommand implements Command {
         }
 
         if (workingDirectory == null) {
-            workingDirectory = ".";
+            workingDirectory = Constants.DEFAULT_WORKING_DIRECTORY;
 
             return new File(workingDirectory).getAbsoluteFile();
         }


### PR DESCRIPTION
Refactored Pipeliner IPC file format.

Lines are now in the format.

`Base64(name) Base64(value)`

Example:

variable name -> `test.property`
variable value -> `test.value`

Line format:

`dGVzdC5wcm9wZXJ0eQ== dGVzdC52YWx1ZQ==`
