### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/manual-build.yaml
+++ b/.github/workflows/manual-build.yaml
@@ -1,5 +1,7 @@
 name: Manual Build
 on: [workflow_dispatch]
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Potential fix for [https://github.com/verifyica-team/pipeliner/security/code-scanning/1](https://github.com/verifyica-team/pipeliner/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will specify the minimal permissions required for the workflow to function. Based on the steps in the workflow, it appears that only `contents: read` is necessary, as the workflow primarily involves checking out the repository, setting up dependencies, and running build and test commands. No write permissions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
