### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,6 @@
 name: Build
+permissions:
+  contents: read
 on:
   push:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/verifyica-team/pipeliner/security/code-scanning/2](https://github.com/verifyica-team/pipeliner/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify `contents: read`, which is sufficient for most basic CI workflows. This ensures that the workflow has only the permissions it needs and no unnecessary write access.

The `permissions` block will be added after the `name` field and before the `on` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
