### PR TITLE
Potential fix for code scanning alert no. 3: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/src/main/java/org/verifyica/pipeliner/common/ArchiveExtractor.java
+++ b/src/main/java/org/verifyica/pipeliner/common/ArchiveExtractor.java
@@ -134,7 +134,11 @@ public class ArchiveExtractor {
                 new ZipInputStream(new BufferedInputStream(Files.newInputStream(file), BUFFER_SIZE_BYTES))) {
             ZipEntry zipEntry;
             while ((zipEntry = zipInputStream.getNextEntry()) != null) {
-                Path entryPath = archiveDirectory.resolve(zipEntry.getName());
+                Path entryPath = archiveDirectory.resolve(zipEntry.getName()).normalize();
+                if (!entryPath.startsWith(archiveDirectory)) {
+                    LOGGER.warn("Skipping invalid zip entry: {}", zipEntry.getName());
+                    continue;
+                }
                 if (zipEntry.isDirectory()) {
                     Files.createDirectories(entryPath);
                     setPermissions(entryPath);


### PR DESCRIPTION
Potential fix for [https://github.com/verifyica-team/pipeliner/security/code-scanning/3](https://github.com/verifyica-team/pipeliner/security/code-scanning/3)

To fix the issue, we need to validate the constructed `entryPath` to ensure it remains within the intended `archiveDirectory`. This can be achieved by normalizing the path and checking that it starts with the canonical path of `archiveDirectory`. If the validation fails, the code should throw an exception or skip the entry.

Steps to fix:
1. Normalize the `entryPath` using `toRealPath()` or `normalize()`.
2. Verify that the normalized `entryPath` starts with the canonical path of `archiveDirectory`.
3. If the check fails, log a warning and skip processing the entry.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
